### PR TITLE
Fix/rentals

### DIFF
--- a/contracts/escrow/EscrowManager.sol
+++ b/contracts/escrow/EscrowManager.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-contract EscrowManager is Ownable {
+contract EscrowManager is Ownable, IERC721Receiver {
     IERC721 public nftContract;
     mapping(address => bool) public trustedModules;
 
@@ -16,43 +17,92 @@ contract EscrowManager is Ownable {
 
     mapping(uint256 => Escrow) public escrows;
 
-    event EscrowLocked(address indexed by, uint256 tokenId);
-    event EscrowReleased(address indexed to, uint256 tokenId);
-    event EscrowForfeited(uint256 tokenId);
+    event EscrowLocked(address indexed depositor, uint256 indexed tokenId);
+    event EscrowReleased(address indexed recipient, uint256 indexed tokenId);
+    event EscrowForfeited(address indexed to, uint256 indexed tokenId);
+    event TrustedModuleUpdated(address indexed module, bool trusted);
 
     modifier onlyTrusted() {
-        require(trustedModules[msg.sender], "Not trusted");
+        require(trustedModules[msg.sender], "Escrow: caller not trusted");
         _;
     }
 
     constructor(address _nft) {
+        require(_nft != address(0), "Invalid NFT address");
         nftContract = IERC721(_nft);
     }
+
     function setTrusted(address module, bool trusted) external onlyOwner {
         trustedModules[module] = trusted;
+        emit TrustedModuleUpdated(module, trusted);
     }
 
+    /**
+     * @notice Lock an NFT into escrow. The depositor MUST have approved this contract for tokenId.
+     * @dev Prevents double-lock. Pulls token via safeTransferFrom so custody is consistent.
+     */
     function lockAsset(uint256 tokenId, address depositor) external onlyTrusted {
-        nftContract.transferFrom(depositor, address(this), tokenId);
-        escrows[tokenId] = Escrow(depositor, tokenId, true);
+        require(!escrows[tokenId].locked, "Escrow: already locked");
+        require(depositor != address(0), "Escrow: invalid depositor");
+        require(nftContract.ownerOf(tokenId) == depositor, "Escrow: depositor not owner");
+
+        // Pull the NFT into escrow
+        nftContract.safeTransferFrom(depositor, address(this), tokenId);
+
+        escrows[tokenId] = Escrow({
+            depositor: depositor,
+            tokenId: tokenId,
+            locked: true
+        });
+
         emit EscrowLocked(depositor, tokenId);
     }
 
+    /**
+     * @notice Release an NFT from escrow to recipient. Callable only by trusted modules.
+     */
     function releaseAsset(uint256 tokenId, address recipient) external onlyTrusted {
-        require(escrows[tokenId].locked, "Not locked");
+        require(escrows[tokenId].locked, "Escrow: not locked");
+        require(recipient != address(0), "Escrow: invalid recipient");
+
+        // Remove from mapping before external call to avoid reentrancy issues
         delete escrows[tokenId];
-        nftContract.transferFrom(address(this), recipient, tokenId);
+
+        // Transfer NFT from escrow to recipient
+        nftContract.safeTransferFrom(address(this), recipient, tokenId);
+
         emit EscrowReleased(recipient, tokenId);
     }
 
-    function forfeitAsset(uint256 tokenId) external onlyTrusted {
-        require(escrows[tokenId].locked, "Not locked");
+    /**
+     * @notice Forfeit an escrowed NFT to a specified address (treasury/admin).
+     * @dev Callable by trusted modules only. Transfers token out of escrow to `to`.
+     */
+    function forfeitAsset(uint256 tokenId, address to) external onlyTrusted {
+        require(escrows[tokenId].locked, "Escrow: not locked");
+        require(to != address(0), "Escrow: invalid recipient");
+
         delete escrows[tokenId];
-        emit EscrowForfeited(tokenId);
-        // Token remains in contract or burned by admin separately
+
+        // Transfer NFT to designated address
+        nftContract.safeTransferFrom(address(this), to, tokenId);
+
+        emit EscrowForfeited(to, tokenId);
     }
 
     function isLocked(uint256 tokenId) external view returns (bool) {
         return escrows[tokenId].locked;
+    }
+
+    /**
+     * @notice ERC721 receiver handler so safeTransferFrom to this contract succeeds.
+     */
+    function onERC721Received(
+        address /*operator*/,
+        address /*from*/,
+        uint256 /*tokenId*/,
+        bytes calldata /*data*/
+    ) external pure override returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
     }
 }

--- a/contracts/finance/LoanModule.sol
+++ b/contracts/finance/LoanModule.sol
@@ -3,16 +3,20 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./InstallmentLogic.sol";
 
 interface IEscrowManager {
-    function lockAsset(address nft, uint256 tokenId) external;
-    function releaseAsset(address nft, uint256 tokenId, address to) external;
-    function forfeitAsset(address nft, uint256 tokenId, address to) external;
+    function lockAsset(uint256 tokenId, address depositor) external;
+    function releaseAsset(uint256 tokenId, address to) external;
+    function forfeitAsset(uint256 tokenId, address to) external;
 }
 
-contract LoanModule is Ownable {
+contract LoanModule is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     IERC721 public nft;
     IERC20 public token;
     IEscrowManager public escrow;
@@ -32,11 +36,13 @@ contract LoanModule is Ownable {
     uint256 public loanDuration = 30 days;
     uint8 public maxInstallments = 4;
 
-    event LoanRequested(uint256 tokenId, address borrower, uint256 amount);
-    event Repaid(uint256 tokenId, address borrower, uint256 amount);
-    event Liquidated(uint256 tokenId, address liquidator);
+    event LoanRequested(uint256 indexed tokenId, address indexed borrower, uint256 amount);
+    event Repaid(uint256 indexed tokenId, address indexed borrower, uint256 amount);
+    event LateRepayment(uint256 indexed tokenId, address indexed borrower, uint256 amount, uint256 timestamp);
+    event Liquidated(uint256 indexed tokenId, address indexed liquidator);
 
     constructor(address _nft, address _token, address _escrow) {
+        require(_nft != address(0) && _token != address(0) && _escrow != address(0), "Invalid addresses");
         nft = IERC721(_nft);
         token = IERC20(_token);
         escrow = IEscrowManager(_escrow);
@@ -47,14 +53,19 @@ contract LoanModule is Ownable {
         token = IERC20(_token);
     }
 
-    function requestLoan(uint256 tokenId, uint256 amount) external {
-        require(nft.ownerOf(tokenId) == msg.sender, "Not token owner");
-        require(amount > 0, "Invalid amount");
-        require(!loans[tokenId].active, "Loan exists");
+    /**
+     * @notice Request a loan using an NFT as collateral.
+     * @dev The borrower must approve the escrow contract to transfer the NFT (approve/ setApprovalForAll).
+     *      LoanModule will call escrow.lockAsset(tokenId, borrower) — EscrowManager pulls the NFT.
+     */
+    function requestLoan(uint256 tokenId, uint256 amount) external nonReentrant {
+        require(nft.ownerOf(tokenId) == msg.sender, "Loan: not token owner");
+        require(amount > 0, "Loan: invalid amount");
+        require(!loans[tokenId].active, "Loan: loan exists");
 
-        // Lock NFT into escrow
-        nft.transferFrom(msg.sender, address(escrow), tokenId);
-        escrow.lockAsset(address(nft), tokenId);
+        // Ask escrow to pull the NFT from borrower into escrow.
+        // Borrower must have approved the escrow contract for this tokenId.
+        escrow.lockAsset(tokenId, msg.sender);
 
         loans[tokenId] = Loan({
             borrower: msg.sender,
@@ -67,38 +78,57 @@ contract LoanModule is Ownable {
 
         installments[tokenId] = InstallmentLogic.createPlan(amount, maxInstallments);
 
-        // Send loan tokens to borrower
-        token.transfer(msg.sender, amount);
+        // Send loan tokens to borrower (escrow/treasury should have balance)
+        token.safeTransfer(msg.sender, amount);
 
         emit LoanRequested(tokenId, msg.sender, amount);
     }
 
-    function repayLoan(uint256 tokenId, uint256 amount) external {
+    /**
+     * @notice Repay part or all of a loan.
+     * @dev Pull tokens first, then update internal accounting, then possibly release NFT.
+     */
+    function repayLoan(uint256 tokenId, uint256 amount) external nonReentrant {
         Loan storage loan = loans[tokenId];
-        require(loan.active, "No active loan");
-        require(msg.sender == loan.borrower, "Not borrower");
+        require(loan.active, "Loan: no active loan");
+        require(msg.sender == loan.borrower, "Loan: not borrower");
+        require(amount > 0, "Loan: invalid amount");
 
+        // Pull repayment tokens from borrower into this contract
+        token.safeTransferFrom(msg.sender, address(this), amount);
+
+        // Update installment plan & loan state
         InstallmentLogic.InstallmentPlan storage plan = installments[tokenId];
         (uint256 remaining, bool isLate) = InstallmentLogic.payInstallment(plan, amount, block.timestamp);
 
         loan.paid += amount;
 
-        token.transferFrom(msg.sender, address(this), amount);
         emit Repaid(tokenId, msg.sender, amount);
 
+        // Emit a late repayment event so off-chain monitoring can react
+        if (isLate) {
+            emit LateRepayment(tokenId, msg.sender, amount, block.timestamp);
+        }
+
         if (remaining == 0) {
+            // Fully repaid: close loan and release NFT to borrower
             loan.active = false;
-            escrow.releaseAsset(address(nft), tokenId, loan.borrower);
+            escrow.releaseAsset(tokenId, loan.borrower);
         }
     }
 
-    function liquidateLoan(uint256 tokenId) external onlyOwner {
+    /**
+     * @notice Liquidate a loan that is past its deadline. Only owner can call (or replace with multisig).
+     */
+    function liquidateLoan(uint256 tokenId) external onlyOwner nonReentrant {
         Loan storage loan = loans[tokenId];
-        require(loan.active, "Loan inactive");
-        require(block.timestamp > loan.deadline, "Loan not expired");
+        require(loan.active, "Loan: inactive");
+        require(block.timestamp > loan.deadline, "Loan: not expired");
 
         loan.active = false;
-        escrow.forfeitAsset(address(nft), tokenId, owner());
+
+        // Forfeit collateral to owner (treasury/admin)
+        escrow.forfeitAsset(tokenId, owner());
 
         emit Liquidated(tokenId, msg.sender);
     }

--- a/contracts/marketplace/AuctionModule.sol
+++ b/contracts/marketplace/AuctionModule.sol
@@ -3,9 +3,23 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract AuctionModule is Ownable {
+interface IEscrowManager {
+    function lockAsset(uint256 tokenId, address depositor) external;
+    function releaseAsset(uint256 tokenId, address recipient) external;
+    function forfeitAsset(uint256 tokenId, address to) external;
+}
+
+interface IRoyaltyManager {
+    function distributeRoyaltyFromContract(uint256 tokenId, uint256 salePrice) external returns (uint256);
+}
+
+contract AuctionModule is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     struct Auction {
         address seller;
         uint256 minBid;
@@ -15,25 +29,71 @@ contract AuctionModule is Ownable {
         bool active;
     }
 
-    IERC721 public nft;
-    IERC20 public paymentToken;
+    IERC721 public immutable nft;
+    IERC20 public immutable paymentToken;
+    IEscrowManager public immutable escrow;
+    IRoyaltyManager public royaltyManager;
+    address public treasury;
+    uint256 public platformFeeBps = 500; // 5%
+    uint256 public constant BPS_DENOMINATOR = 10000;
 
+    // tokenId => auction
     mapping(uint256 => Auction) public auctions;
 
-    event AuctionStarted(uint256 tokenId, uint256 minBid, uint256 endTime);
-    event BidPlaced(uint256 tokenId, address bidder, uint256 amount);
-    event AuctionEnded(uint256 tokenId, address winner, uint256 amount);
+    // bidder => amount available to withdraw (accumulates refunds across auctions)
+    mapping(address => uint256) public pendingReturns;
 
-    constructor(address _nft, address _token) {
+    event AuctionCreated(uint256 indexed tokenId, address indexed seller, uint256 minBid, uint256 endTime);
+    event BidPlaced(uint256 indexed tokenId, address indexed bidder, uint256 amount);
+    event AuctionSettled(uint256 indexed tokenId, address indexed winner, uint256 amount, uint256 royaltyPaid, uint256 platformFee);
+    event AuctionCancelled(uint256 indexed tokenId, address indexed seller);
+    event Withdrawn(address indexed bidder, uint256 amount);
+
+    constructor(
+        address _nft,
+        address _paymentToken,
+        address _escrow,
+        address _treasury,
+        address _royaltyManager
+    ) {
+        require(_nft != address(0) && _paymentToken != address(0) && _escrow != address(0) && _treasury != address(0), "Invalid addresses");
         nft = IERC721(_nft);
-        paymentToken = IERC20(_token);
+        paymentToken = IERC20(_paymentToken);
+        escrow = IEscrowManager(_escrow);
+        treasury = _treasury;
+        if (_royaltyManager != address(0)) {
+            royaltyManager = IRoyaltyManager(_royaltyManager);
+        }
     }
 
-    function startAuction(uint256 tokenId, uint256 minBid, uint256 duration) external {
-        require(nft.ownerOf(tokenId) == msg.sender, "Not owner");
-        require(duration >= 1 hours, "Too short");
+    /* ===================== Admin ===================== */
 
-        nft.transferFrom(msg.sender, address(this), tokenId);
+    function setRoyaltyManager(address _rm) external onlyOwner {
+        royaltyManager = IRoyaltyManager(_rm);
+    }
+
+    function setTreasury(address _treasury) external onlyOwner {
+        require(_treasury != address(0), "Invalid treasury");
+        treasury = _treasury;
+    }
+
+    function setPlatformFee(uint256 bps) external onlyOwner {
+        require(bps <= 1000, "Max 10%");
+        platformFeeBps = bps;
+    }
+
+    /* ===================== Auction lifecycle ===================== */
+
+    /// @notice Start an auction. Seller must approve EscrowManager to pull the NFT.
+    function startAuction(uint256 tokenId, uint256 minBid, uint256 duration) external nonReentrant {
+        require(duration >= 1 hours, "Duration too short");
+        require(minBid > 0, "minBid > 0");
+        require(!auctions[tokenId].active, "Auction exists");
+        require(nft.ownerOf(tokenId) == msg.sender, "Not owner");
+
+        // Lock NFT into escrow; escrow pulls NFT from seller (seller must have approved escrow)
+        escrow.lockAsset(tokenId, msg.sender);
+
         auctions[tokenId] = Auction({
             seller: msg.sender,
             minBid: minBid,
@@ -43,39 +103,137 @@ contract AuctionModule is Ownable {
             active: true
         });
 
-        emit AuctionStarted(tokenId, minBid, block.timestamp + duration);
+        emit AuctionCreated(tokenId, msg.sender, minBid, block.timestamp + duration);
     }
 
-    function placeBid(uint256 tokenId, uint256 amount) external {
-        Auction storage auction = auctions[tokenId];
-        require(auction.active, "Not active");
-        require(block.timestamp < auction.endTime, "Auction ended");
-        require(amount > auction.highestBid && amount >= auction.minBid, "Low bid");
+    /// @notice Place a bid. Buyer must approve paymentToken to this contract for `amount`.
+    function placeBid(uint256 tokenId, uint256 amount) external nonReentrant {
+        Auction storage auc = auctions[tokenId];
+        require(auc.active, "Not active");
+        require(block.timestamp < auc.endTime, "Auction ended");
+        require(msg.sender != auc.seller, "Seller cannot bid");
+        require(amount >= auc.minBid && amount > auc.highestBid, "Bid too low");
 
-        if (auction.highestBid > 0) {
-            paymentToken.transfer(auction.highestBidder, auction.highestBid);
+        // Pull funds from bidder first
+        paymentToken.safeTransferFrom(msg.sender, address(this), amount);
+
+        // If there is an existing highest bidder, add their funds to pendingReturns (pull to them)
+        if (auc.highestBid > 0) {
+            pendingReturns[auc.highestBidder] += auc.highestBid;
         }
 
-        paymentToken.transferFrom(msg.sender, address(this), amount);
-        auction.highestBid = amount;
-        auction.highestBidder = msg.sender;
+        // Update highest
+        auc.highestBid = amount;
+        auc.highestBidder = msg.sender;
 
         emit BidPlaced(tokenId, msg.sender, amount);
     }
 
-    function finalizeAuction(uint256 tokenId) external {
-        Auction memory auction = auctions[tokenId];
-        require(auction.active, "Already finalized");
-        require(block.timestamp >= auction.endTime, "Too early");
+    /// @notice Withdraw refundable funds for outbid bidders
+    function withdrawReturns() external nonReentrant {
+        uint256 amount = pendingReturns[msg.sender];
+        require(amount > 0, "No returns");
+        pendingReturns[msg.sender] = 0;
+        paymentToken.safeTransfer(msg.sender, amount);
+        emit Withdrawn(msg.sender, amount);
+    }
 
-        auctions[tokenId].active = false;
+    /// @notice Cancel an auction before any bids have been placed. Returns NFT to seller.
+    function cancelAuction(uint256 tokenId) external nonReentrant {
+        Auction storage auc = auctions[tokenId];
+        require(auc.active, "Not active");
+        require(auc.seller == msg.sender || msg.sender == owner(), "Not seller/owner");
+        require(auc.highestBid == 0, "Has bids");
 
-        if (auction.highestBid > 0) {
-            nft.transferFrom(address(this), auction.highestBidder, tokenId);
-            paymentToken.transfer(auction.seller, auction.highestBid);
-            emit AuctionEnded(tokenId, auction.highestBidder, auction.highestBid);
-        } else {
-            nft.transferFrom(address(this), auction.seller, tokenId);
+        auc.active = false;
+        // Return NFT to seller via escrow release
+        escrow.releaseAsset(tokenId, auc.seller);
+
+        emit AuctionCancelled(tokenId, auc.seller);
+        delete auctions[tokenId];
+    }
+
+    /// @notice Finalize auction after end time. Transfers NFT and distributes funds.
+    function finalizeAuction(uint256 tokenId) external nonReentrant {
+        Auction storage auc = auctions[tokenId];
+        require(auc.active, "Not active or already finalized");
+        require(block.timestamp >= auc.endTime, "Too early");
+
+        // mark inactive before external calls for safety
+        auc.active = false;
+
+        if (auc.highestBid == 0) {
+            // No bids: return NFT to seller
+            escrow.releaseAsset(tokenId, auc.seller);
+            delete auctions[tokenId];
+            emit AuctionSettled(tokenId, address(0), 0, 0, 0);
+            return;
         }
+
+        uint256 finalPrice = auc.highestBid;
+        address winner = auc.highestBidder;
+
+        // Calculate platform fee
+        uint256 platformFee = (finalPrice * platformFeeBps) / BPS_DENOMINATOR;
+
+        // Distribute royalties from contract. royaltyPaid is moved out of contract by royaltyManager.
+        uint256 royaltyPaid = 0;
+        if (address(royaltyManager) != address(0)) {
+            royaltyPaid = royaltyManager.distributeRoyaltyFromContract(tokenId, finalPrice);
+            require(royaltyPaid <= finalPrice, "Invalid royalty");
+        }
+
+        // Remaining to seller after royalty and platform fee
+        require(finalPrice >= platformFee + royaltyPaid, "Not enough to cover fees");
+        uint256 sellerProceeds = finalPrice - platformFee - royaltyPaid;
+
+        // Transfer platform fee to treasury
+        if (platformFee > 0) {
+            paymentToken.safeTransfer(treasury, platformFee);
+        }
+
+        // Transfer seller proceeds
+        if (sellerProceeds > 0) {
+            paymentToken.safeTransfer(auc.seller, sellerProceeds);
+        }
+
+        // Transfer NFT to winner
+        escrow.releaseAsset(tokenId, winner);
+
+        emit AuctionSettled(tokenId, winner, finalPrice, royaltyPaid, platformFee);
+
+        // clean up
+        delete auctions[tokenId];
+    }
+
+    /// @notice Force-forfeit auction collateral to seller (owner-only emergency)
+    function forfeitAuctionCollateral(uint256 tokenId) external onlyOwner nonReentrant {
+        Auction storage auc = auctions[tokenId];
+        require(auc.active, "Not active");
+        // mark inactive to avoid reuse
+        auc.active = false;
+
+        escrow.forfeitAsset(tokenId, auc.seller);
+        // Refund highest bidder if present
+        if (auc.highestBid > 0) {
+            pendingReturns[auc.highestBidder] += auc.highestBid;
+        }
+
+        emit AuctionCancelled(tokenId, auc.seller);
+        delete auctions[tokenId];
+    }
+
+    /* ============ Views ============ */
+
+    function getAuction(uint256 tokenId) external view returns (
+        address seller,
+        uint256 minBid,
+        uint256 endTime,
+        address highestBidder,
+        uint256 highestBid,
+        bool active
+    ) {
+        Auction memory a = auctions[tokenId];
+        return (a.seller, a.minBid, a.endTime, a.highestBidder, a.highestBid, a.active);
     }
 }

--- a/contracts/marketplace/BiddingSystem.sol
+++ b/contracts/marketplace/BiddingSystem.sol
@@ -3,59 +3,130 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract BiddingSystem is Ownable {
+interface IEscrowManager {
+    function lockAsset(uint256 tokenId, address depositor) external;
+}
+
+contract BiddingSystem is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     struct Bid {
         address bidder;
         uint256 amount;
+        uint256 timestamp;
     }
 
-    IERC721 public nft;
-    IERC20 public token;
+    IERC721 public immutable nft;
+    IERC20 public immutable paymentToken;
+    IEscrowManager public immutable escrow;
 
-    mapping(uint256 => Bid[]) public bids;
+    // tokenId => list of bids
+    mapping(uint256 => Bid[]) private _bids;
 
-    event BidPlaced(uint256 tokenId, address bidder, uint256 amount);
-    event BidAccepted(uint256 tokenId, address winner, uint256 amount);
-    event BidCancelled(uint256 tokenId, address bidder);
+    // tokenId => auto accept price
+    mapping(uint256 => uint256) public autoAcceptPrice;
 
-    constructor(address _nft, address _token) {
+    event BidSubmitted(uint256 indexed tokenId, address indexed bidder, uint256 amount);
+    event BidAccepted(uint256 indexed tokenId, address indexed winner, uint256 amount);
+    event BidRejected(uint256 indexed tokenId, address indexed bidder, uint256 amount);
+    event AutoAcceptPriceSet(uint256 indexed tokenId, uint256 price);
+
+    constructor(address _nft, address _token, address _escrow) {
+        require(_nft != address(0) && _token != address(0) && _escrow != address(0), "Invalid address");
         nft = IERC721(_nft);
-        token = IERC20(_token);
+        paymentToken = IERC20(_token);
+        escrow = IEscrowManager(_escrow);
     }
 
-    function placeBid(uint256 tokenId, uint256 amount) external {
+    /* ----------------- Seller Config ----------------- */
+    function setAutoAcceptPrice(uint256 tokenId, uint256 price) external {
+        require(nft.ownerOf(tokenId) == msg.sender, "Not NFT owner");
+        autoAcceptPrice[tokenId] = price;
+        emit AutoAcceptPriceSet(tokenId, price);
+    }
+
+    /* ----------------- Bid Logic ----------------- */
+    function placeBid(uint256 tokenId, uint256 amount) external nonReentrant {
         require(amount > 0, "Zero bid");
-        token.transferFrom(msg.sender, address(this), amount);
-        bids[tokenId].push(Bid(msg.sender, amount));
 
-        emit BidPlaced(tokenId, msg.sender, amount);
+        // Ensure bid is higher than the current highest bid
+        uint256 currentHighest = _highestBid(tokenId);
+        require(amount > currentHighest, "Bid not higher than current");
+
+        // Pull payment tokens from bidder
+        paymentToken.safeTransferFrom(msg.sender, address(this), amount);
+
+        _bids[tokenId].push(Bid({
+            bidder: msg.sender,
+            amount: amount,
+            timestamp: block.timestamp
+        }));
+
+        emit BidSubmitted(tokenId, msg.sender, amount);
+
+        // Auto accept if meets threshold
+        uint256 threshold = autoAcceptPrice[tokenId];
+        if (threshold > 0 && amount >= threshold) {
+            _acceptBidInternal(tokenId, _bids[tokenId].length - 1);
+        }
     }
 
-    function cancelBid(uint256 tokenId) external {
-        Bid[] storage list = bids[tokenId];
-        for (uint i = 0; i < list.length; i++) {
+    function cancelBid(uint256 tokenId) external nonReentrant {
+        Bid[] storage list = _bids[tokenId];
+        for (uint256 i = 0; i < list.length; i++) {
             if (list[i].bidder == msg.sender) {
-                token.transfer(msg.sender, list[i].amount);
+                uint256 refund = list[i].amount;
+                paymentToken.safeTransfer(msg.sender, refund);
+
+                emit BidRejected(tokenId, msg.sender, refund);
+
                 list[i] = list[list.length - 1];
                 list.pop();
-                emit BidCancelled(tokenId, msg.sender);
                 return;
             }
         }
         revert("No bid found");
     }
 
-    function acceptBid(uint256 tokenId, uint256 index) external {
-        Bid memory accepted = bids[tokenId][index];
+    function acceptBid(uint256 tokenId, uint256 index) external nonReentrant {
         require(nft.ownerOf(tokenId) == msg.sender, "Not owner");
+        _acceptBidInternal(tokenId, index);
+    }
 
-        nft.transferFrom(msg.sender, accepted.bidder, tokenId);
-        token.transfer(msg.sender, accepted.amount);
+    function _acceptBidInternal(uint256 tokenId, uint256 index) internal {
+        require(index < _bids[tokenId].length, "Invalid bid index");
+        Bid memory accepted = _bids[tokenId][index];
+        require(accepted.amount > 0, "Invalid bid");
 
-        delete bids[tokenId];
+        address seller = nft.ownerOf(tokenId);
+
+    // Lock NFT into escrow (seller must have approved escrow beforehand)
+    escrow.lockAsset(tokenId, seller);
+
+        // Pay seller immediately
+        paymentToken.safeTransfer(seller, accepted.amount);
+
+        // Clear bids for tokenId
+        delete _bids[tokenId];
 
         emit BidAccepted(tokenId, accepted.bidder, accepted.amount);
+    }
+
+    /* ----------------- View ----------------- */
+    function getBids(uint256 tokenId) external view returns (Bid[] memory) {
+        return _bids[tokenId];
+    }
+
+    function _highestBid(uint256 tokenId) internal view returns (uint256 highest) {
+        Bid[] storage list = _bids[tokenId];
+        for (uint256 i = 0; i < list.length; i++) {
+            if (list[i].amount > highest) {
+                highest = list[i].amount;
+            }
+        }
     }
 }

--- a/contracts/marketplace/BuyNowPayLater.sol
+++ b/contracts/marketplace/BuyNowPayLater.sol
@@ -4,21 +4,31 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 interface IEscrowManager {
-    function lockAsset(address nft, uint256 tokenId) external;
-    function releaseAsset(address nft, uint256 tokenId, address to) external;
+    function lockAsset(uint256 tokenId, address owner) external;
+    function releaseAsset(uint256 tokenId, address to) external;
+    function forfeitAsset(uint256 tokenId, address to) external;
+}
+
+interface IRoyaltyManager {
+    function distributeRoyaltyFromContract(uint256 tokenId, uint256 salePrice) external returns (uint256);
 }
 
 contract BuyNowPayLater is Ownable {
-    IERC20 public paymentToken;
-    IERC721 public nft;
-    IEscrowManager public escrow;
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable paymentToken;
+    IERC721 public immutable nft;
+    IEscrowManager public immutable escrow;
+    IRoyaltyManager public royaltyManager;
 
     uint256 public defaultInstallments = 3;
 
     struct BNPL {
         address buyer;
+        address seller;
         uint256 totalPrice;
         uint256 downPayment;
         uint256 paid;
@@ -28,60 +38,98 @@ contract BuyNowPayLater is Ownable {
 
     mapping(uint256 => BNPL) public plans;
 
-    event BNPLStarted(uint256 tokenId, address buyer);
-    event InstallmentPaid(uint256 tokenId, uint256 amount);
-    event BNPLDefaulted(uint256 tokenId);
+    event BNPLStarted(
+        uint256 indexed tokenId,
+        address indexed buyer,
+        address indexed seller,
+        uint256 price,
+        uint256 downPayment
+    );
+    event InstallmentPaid(uint256 indexed tokenId, uint256 amount, uint256 totalPaid);
+    event BNPLCompleted(uint256 indexed tokenId, address indexed buyer);
+    event BNPLDefaulted(uint256 indexed tokenId, address indexed seller);
 
-    constructor(address _nft, address _token, address _escrow) {
+    constructor(
+        address _nft,
+        address _token,
+        address _escrow,
+        address _royaltyManager
+    ) {
+        require(_nft != address(0) && _token != address(0) && _escrow != address(0) && _royaltyManager != address(0), "Invalid address");
         nft = IERC721(_nft);
         paymentToken = IERC20(_token);
         escrow = IEscrowManager(_escrow);
+        royaltyManager = IRoyaltyManager(_royaltyManager);
     }
 
-    function initiateBNPL(uint256 tokenId, uint256 totalPrice, uint256 downPayment) external {
+    function initiateBNPL(
+        uint256 tokenId,
+        uint256 totalPrice,
+        uint256 downPayment,
+        uint8 installments
+    ) external {
         require(nft.ownerOf(tokenId) == msg.sender, "Not owner");
         require(totalPrice > 0 && downPayment > 0, "Invalid terms");
+        require(installments > 0, "Invalid installment count");
+        require(downPayment < totalPrice, "Downpayment must be less than price");
 
-        nft.transferFrom(msg.sender, address(escrow), tokenId);
-        escrow.lockAsset(address(nft), tokenId);
+    // Transfer NFT to escrow for custody: seller must approve escrow beforehand.
+    escrow.lockAsset(tokenId, msg.sender);
+
+        // Transfer downpayment to contract
+        paymentToken.safeTransferFrom(msg.sender, address(this), downPayment);
+
+        // Pay royalties from downpayment if applicable
+        royaltyManager.distributeRoyaltyFromContract(tokenId, downPayment);
 
         plans[tokenId] = BNPL({
-            buyer: msg.sender,
+            buyer: address(0), // Buyer will pay installments
+            seller: msg.sender,
             totalPrice: totalPrice,
             downPayment: downPayment,
             paid: downPayment,
-            deadline: block.timestamp + 30 days,
-            installments: uint8(defaultInstallments)
+            deadline: block.timestamp + (installments * 30 days),
+            installments: installments
         });
 
-        emit BNPLStarted(tokenId, msg.sender);
+        emit BNPLStarted(tokenId, address(0), msg.sender, totalPrice, downPayment);
     }
 
     function payInstallment(uint256 tokenId, uint256 amount) external {
         BNPL storage plan = plans[tokenId];
-        require(plan.buyer == msg.sender, "Not buyer");
+        require(plan.seller != address(0), "Plan not found");
         require(block.timestamp <= plan.deadline, "Deadline passed");
+        require(amount > 0, "Invalid payment");
         require(plan.paid + amount <= plan.totalPrice, "Overpay");
 
-        paymentToken.transferFrom(msg.sender, address(this), amount);
+        // If this is first installment, set buyer
+        if (plan.buyer == address(0)) {
+            plan.buyer = msg.sender;
+        } else {
+            require(plan.buyer == msg.sender, "Not buyer");
+        }
+
+        paymentToken.safeTransferFrom(msg.sender, address(this), amount);
         plan.paid += amount;
 
-        emit InstallmentPaid(tokenId, amount);
+        emit InstallmentPaid(tokenId, amount, plan.paid);
 
-        if (plan.paid == plan.totalPrice) {
-            escrow.releaseAsset(address(nft), tokenId, plan.buyer);
+        if (plan.paid >= plan.totalPrice) {
+            escrow.releaseAsset(tokenId, plan.buyer);
+            paymentToken.safeTransfer(plan.seller, plan.paid);
+            emit BNPLCompleted(tokenId, plan.buyer);
             delete plans[tokenId];
         }
     }
 
-    function defaulted(uint256 tokenId) external onlyOwner {
+    function markDefault(uint256 tokenId) external {
         BNPL storage plan = plans[tokenId];
+        require(plan.seller != address(0), "Plan not found");
         require(block.timestamp > plan.deadline, "Still active");
 
-        escrow.releaseAsset(address(nft), tokenId, owner());
+        escrow.forfeitAsset(tokenId, plan.seller);
+        emit BNPLDefaulted(tokenId, plan.seller);
         delete plans[tokenId];
-
-        emit BNPLDefaulted(tokenId);
     }
 
     function setInstallments(uint8 count) external onlyOwner {

--- a/contracts/nft/BoostEngine.sol
+++ b/contracts/nft/BoostEngine.sol
@@ -3,28 +3,37 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract BoostEngine is Ownable {
+    using SafeERC20 for IERC20;
+
     IERC20 public paymentToken;
     address public treasury;
 
-    uint256 public boostRatePerDay = 5 * 10 ** 18;
+    // Fee per day in payment token units (decimals as per token)
+    uint256 public boostFeePerDay = 5 * 10**18;
 
     mapping(uint256 => uint256) public boostedUntil;
 
-    event NFTBoosted(uint256 tokenId, address user, uint256 duration);
+    event NFTBoosted(uint256 indexed tokenId, address indexed user, uint256 daysCount, uint256 boostedUntil);
 
     constructor(address _token, address _treasury) {
+        require(_token != address(0), "Invalid payment token");
+        require(_treasury != address(0), "Invalid treasury");
         paymentToken = IERC20(_token);
         treasury = _treasury;
     }
 
+    /// @notice Boost NFT for a number of days
     function boostNFT(uint256 tokenId, uint256 daysCount) external {
         require(daysCount > 0, "Invalid boost period");
-        uint256 fee = daysCount * boostRatePerDay;
+        require(treasury != address(0), "Treasury not set");
 
-        // Transfer boost fee to treasury
-        IERC20(paymentToken).transferFrom(msg.sender, treasury, fee);
+        uint256 fee = daysCount * boostFeePerDay;
+
+        // Transfer fee safely to treasury
+        paymentToken.safeTransferFrom(msg.sender, treasury, fee);
 
         uint256 currentEnd = boostedUntil[tokenId];
         uint256 newEnd = block.timestamp + (daysCount * 1 days);
@@ -36,11 +45,11 @@ contract BoostEngine is Ownable {
             boostedUntil[tokenId] = newEnd;
         }
 
-        emit NFTBoosted(tokenId, msg.sender, daysCount);
+        emit NFTBoosted(tokenId, msg.sender, daysCount, boostedUntil[tokenId]);
     }
 
-    function setBoostRate(uint256 newRate) external onlyOwner {
-        boostRatePerDay = newRate;
+    function setBoostFeePerDay(uint256 newFee) external onlyOwner {
+        boostFeePerDay = newFee;
     }
 
     function setPaymentToken(address _token) external onlyOwner {
@@ -49,7 +58,6 @@ contract BoostEngine is Ownable {
     }
 
     function setTreasury(address _treasury) external onlyOwner {
-        require(_treasury != address(0), "Invalid treasury");
         treasury = _treasury;
     }
 

--- a/contracts/nft/RoyaltyManager.sol
+++ b/contracts/nft/RoyaltyManager.sol
@@ -3,13 +3,17 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+/// @notice RoyaltyManager compatible with MarketplaceCore pull-from-contract flow.
 contract RoyaltyManager is Ownable {
-    uint256 public platformCut = 200; // 2% = 200 basis points
-    uint256 public constant MAX_ROYALTY = 1000; // 10%
+    using SafeERC20 for IERC20;
+
+    uint256 public platformCut = 200; // 2% of royalty amount
+    uint256 public constant MAX_ROYALTY = 1000; // 10% max royalty
 
     address public platformTreasury;
-    address public paymentToken;
+    IERC20 public paymentToken;
 
     struct Royalty {
         uint256 percent; // out of 10,000 (basis points)
@@ -18,33 +22,45 @@ contract RoyaltyManager is Ownable {
 
     mapping(uint256 => Royalty) public royalties;
 
-    event RoyaltySet(uint256 tokenId, address creator, uint256 percent);
-    event RoyaltyPaid(uint256 tokenId, address to, uint256 amount, address buyer);
+    event RoyaltySet(uint256 indexed tokenId, address indexed creator, uint256 percent);
+    event RoyaltyPaid(uint256 indexed tokenId, address indexed creator, uint256 totalRoyalty, uint256 creatorAmount, uint256 platformAmount);
 
     constructor(address _paymentToken, address _treasury) {
-        paymentToken = _paymentToken;
+        require(_paymentToken != address(0), "Invalid payment token");
+        require(_treasury != address(0), "Invalid treasury");
+        paymentToken = IERC20(_paymentToken);
         platformTreasury = _treasury;
     }
 
+    /// @notice Set royalty info for a tokenId.
     function setRoyalty(uint256 tokenId, address creator, uint256 percent) external onlyOwner {
         require(percent <= MAX_ROYALTY, "Royalty too high");
+        require(creator != address(0), "Invalid creator");
         royalties[tokenId] = Royalty(percent, creator);
         emit RoyaltySet(tokenId, creator, percent);
     }
 
-    function distributeRoyalty(uint256 tokenId, uint256 salePrice, address buyer) external {
+    /// @notice Called by marketplace to distribute royalty from funds already held in contract.
+    /// @dev Transfers from this contract's balance, not from buyer.
+    /// @return totalRoyalty amount taken from marketplace funds.
+    function distributeRoyaltyFromContract(uint256 tokenId, uint256 salePrice) external returns (uint256 totalRoyalty) {
         Royalty memory r = royalties[tokenId];
-        require(r.percent > 0, "No royalty set");
+        if (r.percent == 0 || r.creator == address(0)) {
+            return 0; // No royalty set, skip.
+        }
 
-        uint256 royaltyAmount = (salePrice * r.percent) / 10000;
-        uint256 platformAmount = (royaltyAmount * platformCut) / 10000;
-        uint256 creatorAmount = royaltyAmount - platformAmount;
+        totalRoyalty = (salePrice * r.percent) / 10000;
+        uint256 platformAmount = (totalRoyalty * platformCut) / 10000;
+        uint256 creatorAmount = totalRoyalty - platformAmount;
 
-        // Pull funds from buyer (approved beforehand)
-        require(IERC20(paymentToken).transferFrom(buyer, r.creator, creatorAmount), "Creator royalty failed");
-        require(IERC20(paymentToken).transferFrom(buyer, platformTreasury, platformAmount), "Platform fee failed");
+        // Transfer from marketplace's contract balance
+            // Pull funds from caller (marketplace/auction) and forward to recipients
+            paymentToken.safeTransferFrom(msg.sender, r.creator, creatorAmount);
+            if (platformAmount > 0) {
+                paymentToken.safeTransferFrom(msg.sender, platformTreasury, platformAmount);
+            }
 
-        emit RoyaltyPaid(tokenId, r.creator, royaltyAmount, buyer);
+        emit RoyaltyPaid(tokenId, r.creator, totalRoyalty, creatorAmount, platformAmount);
     }
 
     function setPlatformCut(uint256 cutBps) external onlyOwner {
@@ -53,6 +69,7 @@ contract RoyaltyManager is Ownable {
     }
 
     function setTreasury(address newTreasury) external onlyOwner {
+        require(newTreasury != address(0), "Invalid treasury");
         platformTreasury = newTreasury;
     }
 }

--- a/contracts/rentals/LeaseAgreement.sol
+++ b/contracts/rentals/LeaseAgreement.sol
@@ -6,7 +6,9 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 interface IRentalEngine {
     function registerLease(address lessor, address lessee, uint256 tokenId, uint256 duration) external;
+    function endLease(uint256 tokenId) external;
     function forceEndLease(uint256 tokenId) external;
+    function getLessor(uint256 tokenId) external view returns (address);
 }
 
 contract LeaseAgreement is Ownable {
@@ -17,28 +19,33 @@ contract LeaseAgreement is Ownable {
     event LeaseEnded(uint256 indexed tokenId, address endedBy);
 
     constructor(address _nft, address _rentalEngine) {
+        require(_nft != address(0), "Invalid NFT address");
+        require(_rentalEngine != address(0), "Invalid engine address");
         nft = IERC721(_nft);
         rentalEngine = IRentalEngine(_rentalEngine);
     }
 
+    /// @notice Start a lease by transferring NFT to RentalEngine and registering lease
     function startLease(uint256 tokenId, address lessee, uint256 duration) external {
         require(nft.ownerOf(tokenId) == msg.sender, "Not token owner");
         require(duration >= 1 days, "Min duration is 1 day");
 
-        // Transfer to engine, not to lessee directly
-        nft.transferFrom(msg.sender, address(rentalEngine), tokenId);
-
+        // Call engine to register lease (engine will pull NFT)
         rentalEngine.registerLease(msg.sender, lessee, tokenId, duration);
 
         emit LeaseStarted(msg.sender, lessee, tokenId, duration);
     }
 
+    /// @notice End a lease (termination by lessor)
     function endLease(uint256 tokenId) external {
-        rentalEngine.forceEndLease(tokenId);
+        require(msg.sender == rentalEngine.getLessor(tokenId), "Not authorized");
+        rentalEngine.endLease(tokenId);
         emit LeaseEnded(tokenId, msg.sender);
     }
 
+    /// @notice Owner can update the RentalEngine address
     function updateEngine(address newEngine) external onlyOwner {
+        require(newEngine != address(0), "Invalid engine address");
         rentalEngine = IRentalEngine(newEngine);
     }
 }

--- a/contracts/rentals/RentalEngine.sol
+++ b/contracts/rentals/RentalEngine.sol
@@ -2,11 +2,18 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract RentalEngine is Ownable {
+/// @notice Rental engine to manage NFT leases with custody
+contract RentalEngine is Ownable, ERC721Holder, ReentrancyGuard {
     IERC721 public nft;
     address public treasury;
+    uint256 public maxRentalPeriod = 30 days;
+
+    /// @notice Trusted modules (e.g., LeaseAgreement) allowed to call registerLease
+    mapping(address => bool) public trustedModules;
 
     struct Lease {
         address lessor;
@@ -17,21 +24,42 @@ contract RentalEngine is Ownable {
 
     mapping(uint256 => Lease) public leases;
 
-    event Rented(uint256 indexed tokenId, address indexed lessee, uint256 duration);
-    event Returned(uint256 indexed tokenId, address indexed lessee);
-    event Defaulted(uint256 indexed tokenId);
+    event LeaseStarted(uint256 indexed tokenId, address indexed lessee, uint256 duration);
+    event LeaseEnded(uint256 indexed tokenId, address indexed lessee);
+    event LeaseDefaulted(uint256 indexed tokenId);
+    event TrustedModuleUpdated(address indexed module, bool enabled);
 
     constructor(address _nft) {
+        require(_nft != address(0), "Invalid NFT address");
         nft = IERC721(_nft);
     }
 
+    /// @notice Owner can set the treasury
     function setTreasury(address _treasury) external onlyOwner {
         require(_treasury != address(0), "Invalid treasury");
         treasury = _treasury;
     }
 
-    function registerLease(address lessor, address lessee, uint256 tokenId, uint256 duration) external onlyOwner {
+    /// @notice Owner can update trusted modules
+    function setTrustedModule(address module, bool enabled) external onlyOwner {
+        require(module != address(0), "Invalid module");
+        trustedModules[module] = enabled;
+        emit TrustedModuleUpdated(module, enabled);
+    }
+
+    /// @notice Register a lease (only trusted modules)
+    function registerLease(
+        address lessor,
+        address lessee,
+        uint256 tokenId,
+        uint256 duration
+    ) external nonReentrant {
+        require(trustedModules[msg.sender], "Caller not trusted");
         require(!leases[tokenId].active, "Lease already active");
+        require(duration > 0 && duration <= maxRentalPeriod, "Invalid duration");
+
+        // Pull NFT into custody
+        nft.transferFrom(lessor, address(this), tokenId);
 
         leases[tokenId] = Lease({
             lessor: lessor,
@@ -40,44 +68,69 @@ contract RentalEngine is Ownable {
             active: true
         });
 
-        // Transfer to lessee for use (could restrict via wrapper)
-        nft.transferFrom(address(this), lessee, tokenId);
-
-        emit Rented(tokenId, lessee, duration);
+        emit LeaseStarted(tokenId, lessee, duration);
     }
 
-    function returnNFT(uint256 tokenId) external {
+    /// @notice Lessee returns NFT early
+    function returnNFT(uint256 tokenId) external nonReentrant {
         Lease memory lease = leases[tokenId];
         require(lease.active, "Not leased");
         require(msg.sender == lease.lessee, "Only lessee can return");
 
-        // End lease and return NFT to owner
         delete leases[tokenId];
-        nft.transferFrom(msg.sender, lease.lessor, tokenId);
+        nft.transferFrom(address(this), lease.lessor, tokenId);
 
-        emit Returned(tokenId, msg.sender);
+        emit LeaseEnded(tokenId, msg.sender);
     }
 
-    function markDefaulted(uint256 tokenId) external onlyOwner {
+    /// @notice Mark a lease defaulted (after expiry)
+    function markDefaulted(uint256 tokenId) external nonReentrant onlyOwner {
         Lease memory lease = leases[tokenId];
         require(lease.active, "Lease not active");
         require(block.timestamp > lease.expiresAt, "Lease not expired");
 
         delete leases[tokenId];
-        nft.transferFrom(lease.lessee, lease.lessor, tokenId);
+        nft.transferFrom(address(this), lease.lessor, tokenId);
 
-        emit Defaulted(tokenId);
+        emit LeaseDefaulted(tokenId);
     }
 
-    function forceEndLease(uint256 tokenId) external onlyOwner {
+    /// @notice Force end lease (emergency)
+    function forceEndLease(uint256 tokenId) external nonReentrant onlyOwner {
         Lease memory lease = leases[tokenId];
-        if (lease.active) {
-            delete leases[tokenId];
-            nft.transferFrom(lease.lessee, lease.lessor, tokenId);
-            emit Returned(tokenId, lease.lessee);
-        }
+        require(lease.active, "Not leased");
+        
+        delete leases[tokenId];
+        nft.transferFrom(address(this), lease.lessor, tokenId);
+        
+        emit LeaseEnded(tokenId, lease.lessee);
     }
 
+    /// @notice Get lessor of an NFT
+    function getLessor(uint256 tokenId) external view returns (address) {
+        require(leases[tokenId].active, "Not leased");
+        return leases[tokenId].lessor;
+    }
+
+    /// @notice End lease and return NFT to lessor (only trusted modules or on expiry)
+    function endLease(uint256 tokenId) external nonReentrant {
+        Lease memory lease = leases[tokenId];
+        require(lease.active, "Not leased");
+        
+        // Allow trusted modules to end lease anytime
+        bool isTrustedModule = trustedModules[msg.sender];
+        if (!isTrustedModule) {
+            // Direct calls only allowed by lessor after expiry
+            require(msg.sender == lease.lessor, "Only lessor can end lease");
+            require(block.timestamp > lease.expiresAt, "Lease not expired");
+        }
+        
+        delete leases[tokenId];
+        nft.transferFrom(address(this), lease.lessor, tokenId);
+        emit LeaseEnded(tokenId, lease.lessee);
+    }
+
+    /// @notice Returns info about a lease
     function getLeaseInfo(uint256 tokenId) external view returns (Lease memory) {
         return leases[tokenId];
     }

--- a/test/escrow.test.js
+++ b/test/escrow.test.js
@@ -1,48 +1,99 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe(" Token Module (Passing)", function () {
-  let deployer, user1;
-  let token;
+describe("EscrowManager", () => {
+  let deployer, trusted, user1, treasury;
+  let mfh, nft, escrow;
 
-  before(async () => {
-    [deployer, user1] = await ethers.getSigners();
+  beforeEach(async () => {
+    [deployer, trusted, user1, treasury] = await ethers.getSigners();
 
+    // Deploy MFH token
     const MFHToken = await ethers.getContractFactory("MFHToken");
-    token = await MFHToken.deploy(); // Full supply minted to deployer
-    await token.waitForDeployment();
+    mfh = await MFHToken.deploy();
+    await mfh.waitForDeployment();
+
+    // Deploy NFTMinting (uses MFH for mint price)
+    const NFTMinting = await ethers.getContractFactory("NFTMinting");
+    nft = await NFTMinting.deploy(mfh.target);
+    await nft.waitForDeployment();
+
+    // Fund user1 with MFH and approve NFTMinting
+    const mintPrice = await nft.mintPrice();
+    await mfh.transfer(user1.address, mintPrice);
+    await mfh.connect(user1).approve(nft.target, mintPrice);
+
+    // Mint NFT to user1
+    await nft.connect(user1).mintNFT("ipfs://collateral");
+
+    // Deploy EscrowManager bound to NFT contract
+    const EscrowManager = await ethers.getContractFactory("EscrowManager");
+    escrow = await EscrowManager.deploy(nft.target);
+    await escrow.waitForDeployment();
+
+    // Make `trusted` account a trusted module
+    await escrow.connect(deployer).setTrusted(trusted.address, true);
   });
 
-  it("should deploy token with correct name and symbol", async () => {
-    expect(await token.name()).to.equal("MetaFunHub");
-    expect(await token.symbol()).to.equal("MFH");
+  it("should allow trusted module to lock asset", async () => {
+    await nft.connect(user1).approve(escrow.target, 1);
+
+    await expect(
+      escrow.connect(trusted).lockAsset(1, user1.address)
+    ).to.emit(escrow, "EscrowLocked").withArgs(user1.address, 1);
+
+    expect(await escrow.isLocked(1)).to.equal(true);
+    expect(await nft.ownerOf(1)).to.equal(escrow.target);
   });
 
-  it("should return totalSupply equal to MAX_SUPPLY", async () => {
-    const supply = await token.totalSupply();
-    expect(supply).to.equal(ethers.parseEther("1000000000"));
+  it("should prevent double lock", async () => {
+    await nft.connect(user1).approve(escrow.target, 1);
+    await escrow.connect(trusted).lockAsset(1, user1.address);
+
+    await expect(
+      escrow.connect(trusted).lockAsset(1, user1.address)
+    ).to.be.revertedWith("Escrow: already locked");
   });
 
-  it("should allow owner to pause and unpause", async () => {
-    await token.pause();
-    expect(await token.paused()).to.equal(true);
+  it("should restrict lockAsset to trusted modules", async () => {
+    await nft.connect(user1).approve(escrow.target, 1);
 
-    await token.unpause();
-    expect(await token.paused()).to.equal(false);
+    await expect(
+      escrow.connect(user1).lockAsset(1, user1.address)
+    ).to.be.revertedWith("Escrow: caller not trusted");
   });
 
-  it("should emit Burn event when burned", async () => {
-    const burnAmount = ethers.parseEther("1000");
+  it("should release asset to recipient", async () => {
+    await nft.connect(user1).approve(escrow.target, 1);
+    await escrow.connect(trusted).lockAsset(1, user1.address);
 
-    // Transfer some to user1 first (from deployer who owns full supply)
-    await token.transfer(user1.address, burnAmount);
+    await expect(
+      escrow.connect(trusted).releaseAsset(1, user1.address)
+    ).to.emit(escrow, "EscrowReleased").withArgs(user1.address, 1);
 
-    // Burn from user1's balance by owner
-    await expect(token.burn(user1.address, burnAmount))
-      .to.emit(token, "Burn")
-      .withArgs(user1.address, burnAmount);
+    expect(await nft.ownerOf(1)).to.equal(user1.address);
+    expect(await escrow.isLocked(1)).to.equal(false);
+  });
 
-    const userBalance = await token.balanceOf(user1.address);
-    expect(userBalance).to.equal(0);
+  it("should forfeit asset to treasury/admin", async () => {
+    await nft.connect(user1).approve(escrow.target, 1);
+    await escrow.connect(trusted).lockAsset(1, user1.address);
+
+    await expect(
+      escrow.connect(trusted).forfeitAsset(1, treasury.address)
+    ).to.emit(escrow, "EscrowForfeited").withArgs(treasury.address, 1);
+
+    expect(await nft.ownerOf(1)).to.equal(treasury.address);
+    expect(await escrow.isLocked(1)).to.equal(false);
+  });
+
+  it("should not release or forfeit if not locked", async () => {
+    await expect(
+      escrow.connect(trusted).releaseAsset(1, user1.address)
+    ).to.be.revertedWith("Escrow: not locked");
+
+    await expect(
+      escrow.connect(trusted).forfeitAsset(1, treasury.address)
+    ).to.be.revertedWith("Escrow: not locked");
   });
 });

--- a/test/nft.test.js
+++ b/test/nft.test.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { ethers, network } = require("hardhat");
 
-describe(" NFT Module", function () {
+describe("NFTModule", function () {
   let deployer, user1, user2, multisig;
   let token, treasury, nftMinting, royaltyManager, boostEngine;
   let startTimestamp;
@@ -44,13 +44,14 @@ describe(" NFT Module", function () {
     await network.provider.send("evm_mine");
   });
 
-  describe(" NFTMinting.sol", function () {
+  describe("NFTMinting.sol", function () {
     it("should mint NFT with valid metadata and payment", async () => {
       await token.connect(user1).approve(nftMinting.target, ethers.parseEther("10"));
       const metadataURI = "ipfs://test-metadata";
       await expect(nftMinting.connect(user1).mintNFT(metadataURI))
         .to.emit(nftMinting, "NFTMinted")
         .withArgs(user1.address, 1);
+
       expect(await nftMinting.ownerOf(1)).to.equal(user1.address);
       expect(await nftMinting.tokenURI(1)).to.equal(metadataURI);
       expect(await nftMinting.mintedBy(user1.address)).to.equal(1);
@@ -73,16 +74,23 @@ describe(" NFT Module", function () {
         .to.be.revertedWith("Mint limit exceeded");
     });
 
+    it("should fail if allowance is insufficient", async () => {
+      await token.connect(user1).approve(nftMinting.target, ethers.parseEther("5")); // less than mintPrice
+      await expect(nftMinting.connect(user1).mintNFT("ipfs://fail-test"))
+        .to.be.revertedWith("ERC20: insufficient allowance");
+    });
+
     it("should allow owner to set mint price and withdraw fees", async () => {
       await token.connect(user1).approve(nftMinting.target, ethers.parseEther("10"));
       await nftMinting.connect(user1).mintNFT("ipfs://test-metadata");
+
       await nftMinting.setMintPrice(ethers.parseEther("20"));
       expect(await nftMinting.mintPrice()).to.equal(ethers.parseEther("20"));
 
       const initialBalance = await token.balanceOf(deployer.address);
       await nftMinting.withdrawFees(deployer.address);
       const finalBalance = await token.balanceOf(deployer.address);
-      expect(BigInt(finalBalance) - BigInt(initialBalance)).to.equal(ethers.parseEther("10").toString());
+      expect(BigInt(finalBalance) - BigInt(initialBalance)).to.equal(ethers.parseEther("10"));
     });
   });
 
@@ -91,6 +99,7 @@ describe(" NFT Module", function () {
       await expect(royaltyManager.setRoyalty(1, user1.address, 500))
         .to.emit(royaltyManager, "RoyaltySet")
         .withArgs(1, user1.address, 500);
+
       const royalty = await royaltyManager.royalties(1);
       expect(royalty.percent).to.equal(500);
       expect(royalty.creator).to.equal(user1.address);
@@ -101,53 +110,71 @@ describe(" NFT Module", function () {
         .to.be.revertedWith("Royalty too high");
     });
 
-    it("should distribute royalty correctly", async () => {
-      await royaltyManager.setRoyalty(1, user1.address, 500); // 5% royalty
+    it("should distribute royalty correctly via contract", async () => {
+      await royaltyManager.setRoyalty(1, user1.address, 500); // 5%
       const salePrice = ethers.parseEther("100");
-      const royaltyAmount = (salePrice * 500n) / 10000n; // 5 MFH
-      const platformCut = (royaltyAmount * 200n) / 10000n; // 2% of 5 MFH = 0.1 MFH
-      const creatorAmount = royaltyAmount - platformCut; // 4.9 MFH
 
-      await token.connect(user2).approve(royaltyManager.target, royaltyAmount);
-      await expect(royaltyManager.distributeRoyalty(1, salePrice, user2.address))
-        .to.emit(royaltyManager, "RoyaltyPaid")
-        .withArgs(1, user1.address, royaltyAmount, user2.address);
-      expect(await token.balanceOf(user1.address)).to.equal(
-        (BigInt(ethers.parseEther("1000")) + BigInt(creatorAmount)).toString()
-      );
-      expect(await token.balanceOf(treasury.target)).to.equal(platformCut.toString());
+      // Get initial balances
+      const initialCreatorBalance = await token.balanceOf(user1.address);
+      const initialTreasuryBalance = await token.balanceOf(treasury.target);
+
+      await token.connect(user2).approve(royaltyManager.target, salePrice);
+
+      await expect(royaltyManager.connect(user2).distributeRoyaltyFromContract(1, salePrice))
+        .to.emit(royaltyManager, "RoyaltyPaid");
+
+      const royaltyAmount = (salePrice * 500n) / 10000n; // 5% of sale price
+      const platformAmount = (royaltyAmount * 200n) / 10000n; // 2% of royalty
+      const creatorAmount = royaltyAmount - platformAmount;
+
+      // Check balance changes
+      expect(await token.balanceOf(user1.address)).to.equal(initialCreatorBalance + creatorAmount);
+      expect(await token.balanceOf(treasury.target)).to.equal(initialTreasuryBalance + platformAmount);
+    });
+
+    it("should not revert if no royalty set", async () => {
+      const salePrice = ethers.parseEther("50");
+      await token.connect(user2).approve(royaltyManager.target, salePrice);
+      await expect(royaltyManager.connect(user2).distributeRoyaltyFromContract(999, salePrice))
+        .to.not.be.reverted;
     });
 
     it("should allow owner to set platform cut and treasury", async () => {
       await royaltyManager.setPlatformCut(300); // 3%
       expect(await royaltyManager.platformCut()).to.equal(300);
+
       await royaltyManager.setTreasury(user2.address);
       expect(await royaltyManager.platformTreasury()).to.equal(user2.address);
     });
   });
 
-  describe(" BoostEngine.sol", function () {
+  describe("BoostEngine.sol", function () {
     it("should boost NFT with valid duration and payment", async () => {
       await token.connect(user1).approve(boostEngine.target, ethers.parseEther("5"));
       await network.provider.send("evm_setNextBlockTimestamp", [startTimestamp + 100]);
       const boostTimestamp = startTimestamp + 100;
+      const expectedEnd = boostTimestamp + 1 * 86400;
+
       await expect(boostEngine.connect(user1).boostNFT(1, 1))
         .to.emit(boostEngine, "NFTBoosted")
-        .withArgs(1, user1.address, 1);
+        .withArgs(1, user1.address, 1, expectedEnd);
+
       const boostEnd = await boostEngine.boostedUntil(1);
-      expect(boostEnd).to.equal(boostTimestamp + 1 * 86400);
+      expect(boostEnd).to.equal(expectedEnd);
       expect(await boostEngine.isBoosted(1)).to.be.true;
       expect(await token.balanceOf(treasury.target)).to.equal(ethers.parseEther("5"));
     });
 
     it("should extend existing boost", async () => {
       await token.connect(user1).approve(boostEngine.target, ethers.parseEther("15"));
-      await boostEngine.connect(user1).boostNFT(1, 1); // Boost for 1 day
+      await boostEngine.connect(user1).boostNFT(1, 1); // 1 day
       const initialBoostEnd = await boostEngine.boostedUntil(1);
+
       await network.provider.send("evm_setNextBlockTimestamp", [startTimestamp + 3600]);
-      await boostEngine.connect(user1).boostNFT(1, 2); // Extend by 2 days
+      await boostEngine.connect(user1).boostNFT(1, 2); // add 2 days
       const newBoostEnd = await boostEngine.boostedUntil(1);
-      expect(newBoostEnd).to.equal((BigInt(initialBoostEnd) + BigInt(2 * 86400)).toString());
+
+      expect(newBoostEnd).to.equal(BigInt(initialBoostEnd) + 2n * 86400n);
     });
 
     it("should reject boost with zero duration", async () => {
@@ -156,9 +183,18 @@ describe(" NFT Module", function () {
         .to.be.revertedWith("Invalid boost period");
     });
 
+    it("should reject boost if treasury not set", async () => {
+      const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+      await boostEngine.setTreasury(ZERO_ADDRESS);
+      await token.connect(user1).approve(boostEngine.target, ethers.parseEther("5"));
+      await expect(boostEngine.connect(user1).boostNFT(1, 1))
+        .to.be.revertedWith("Treasury not set");
+    });
+
     it("should allow owner to set boost rate and treasury", async () => {
-      await boostEngine.setBoostRate(ethers.parseEther("10"));
-      expect(await boostEngine.boostRatePerDay()).to.equal(ethers.parseEther("10"));
+      await boostEngine.setBoostFeePerDay(ethers.parseEther("10"));
+      expect(await boostEngine.boostFeePerDay()).to.equal(ethers.parseEther("10"));
+
       await boostEngine.setTreasury(user2.address);
       expect(await boostEngine.treasury()).to.equal(user2.address);
     });
@@ -166,9 +202,22 @@ describe(" NFT Module", function () {
     it("should correctly handle boost expiration", async () => {
       await token.connect(user1).approve(boostEngine.target, ethers.parseEther("5"));
       await boostEngine.connect(user1).boostNFT(1, 1);
+
       await network.provider.send("evm_setNextBlockTimestamp", [startTimestamp + 2 * 86400]);
       await network.provider.send("evm_mine");
+
       expect(await boostEngine.isBoosted(1)).to.be.false;
+    });
+
+    it("should correctly stack multiple boosts", async () => {
+      await token.connect(user1).approve(boostEngine.target, ethers.parseEther("20"));
+      await boostEngine.connect(user1).boostNFT(1, 1); // 1 day
+      const firstEnd = await boostEngine.boostedUntil(1);
+
+      await boostEngine.connect(user1).boostNFT(1, 2); // add 2 days
+      const secondEnd = await boostEngine.boostedUntil(1);
+
+      expect(secondEnd).to.equal(BigInt(firstEnd) + 2n * 86400n);
     });
   });
 });

--- a/test/rentals.test.js
+++ b/test/rentals.test.js
@@ -1,58 +1,172 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("NFT Rental System", function () {
+describe("RentalsModule", function () {
   let NFTMinting, RentalEngine, LeaseAgreement;
   let nft, rentalEngine, leaseAgreement;
-  let owner, lessor, lessee, treasury;
+  let owner, lessor, lessee, treasury, other;
   const TOKEN_ID = 1;
   const DURATION = 86400; // 1 day
 
   beforeEach(async function () {
-    [owner, lessor, lessee, treasury] = await ethers.getSigners();
+    [owner, lessor, lessee, treasury, other] = await ethers.getSigners();
 
+    // Deploy MFHToken for minting payments
     const MFHToken = await ethers.getContractFactory("MFHToken");
     const mfh = await MFHToken.deploy();
     await mfh.waitForDeployment();
 
+    // Deploy NFTMinting
     NFTMinting = await ethers.getContractFactory("NFTMinting");
     nft = await NFTMinting.deploy(mfh.target);
     await nft.waitForDeployment();
 
-    // Fund lessor with minting tokens
+    // Fund lessor
     await mfh.transfer(lessor.address, ethers.parseEther("100"));
     await mfh.connect(lessor).approve(nft.target, ethers.parseEther("100"));
 
     // Mint NFT to lessor
     await nft.connect(lessor).mintNFT("ipfs://test-uri");
 
+    // Deploy RentalEngine
     RentalEngine = await ethers.getContractFactory("RentalEngine");
     rentalEngine = await RentalEngine.deploy(nft.target);
     await rentalEngine.waitForDeployment();
+    await rentalEngine.setTreasury(treasury.address);
 
+    // Deploy LeaseAgreement
     LeaseAgreement = await ethers.getContractFactory("LeaseAgreement");
     leaseAgreement = await LeaseAgreement.deploy(nft.target, rentalEngine.target);
     await leaseAgreement.waitForDeployment();
 
-    await rentalEngine.setTreasury(treasury.address);
+    // Mark LeaseAgreement as a trusted module in RentalEngine
+    await rentalEngine.setTrustedModule(leaseAgreement.target, true);
   });
 
-  describe("RentalEngine", function () {
+  describe("RentalEngine.sol", function () {
     it("should set treasury correctly", async function () {
       expect(await rentalEngine.treasury()).to.equal(treasury.address);
     });
 
-    it("should fail to set zero address as treasury", async function () {
+    it("should revert if treasury is zero address", async function () {
       await expect(rentalEngine.setTreasury(ethers.ZeroAddress))
         .to.be.revertedWith("Invalid treasury");
     });
+
+    it("should reject untrusted caller from registering lease", async function () {
+      await expect(
+        rentalEngine.registerLease(lessor.address, lessee.address, TOKEN_ID, DURATION)
+      ).to.be.reverted; // Only trusted modules should call
+    });
   });
 
-  describe("LeaseAgreement", function () {
-    it("should fail if non-owner tries lease", async function () {
+  describe("LeaseAgreement.sol", function () {
+    it("should fail if non-owner tries to start lease", async function () {
       await expect(
         leaseAgreement.connect(lessee).startLease(TOKEN_ID, lessee.address, DURATION)
       ).to.be.revertedWith("Not token owner");
+    });
+
+    it("should start lease correctly", async function () {
+      const ownerOfNFT = await nft.ownerOf(TOKEN_ID);
+      expect(ownerOfNFT).to.equal(lessor.address);
+
+      // Approve RentalEngine to transfer NFT
+      await nft.connect(lessor).approve(rentalEngine.target, TOKEN_ID);
+
+      await expect(leaseAgreement.connect(lessor).startLease(TOKEN_ID, lessee.address, DURATION))
+        .to.emit(leaseAgreement, "LeaseStarted")
+        .withArgs(lessor.address, lessee.address, TOKEN_ID, DURATION);
+
+      // NFT should be in RentalEngine custody
+      expect(await nft.ownerOf(TOKEN_ID)).to.equal(rentalEngine.target);
+
+      // Lease info in engine
+      const lease = await rentalEngine.getLeaseInfo(TOKEN_ID);
+      expect(lease.lessor).to.equal(lessor.address);
+      expect(lease.lessee).to.equal(lessee.address);
+      expect(lease.active).to.be.true;
+    });
+
+    it("should end lease and return NFT", async function () {
+      // Approve RentalEngine to transfer NFT
+      await nft.connect(lessor).approve(rentalEngine.target, TOKEN_ID);
+      await leaseAgreement.connect(lessor).startLease(TOKEN_ID, lessee.address, DURATION);
+
+      // Advance time past lease duration
+      const latestBlock = await ethers.provider.getBlock('latest');
+      await network.provider.send("evm_setNextBlockTimestamp", [latestBlock.timestamp + DURATION + 1]);
+      await network.provider.send("evm_mine");
+
+      await expect(leaseAgreement.connect(lessor).endLease(TOKEN_ID))
+        .to.emit(leaseAgreement, "LeaseEnded")
+        .withArgs(TOKEN_ID, lessor.address);
+
+      // NFT returned to lessor
+      expect(await nft.ownerOf(TOKEN_ID)).to.equal(lessor.address);
+
+      // Lease inactive
+      const lease = await rentalEngine.getLeaseInfo(TOKEN_ID);
+      expect(lease.active).to.be.false;
+    });
+
+    it("should only allow lessor to end lease", async function () {
+      // Approve RentalEngine to transfer NFT
+      await nft.connect(lessor).approve(rentalEngine.target, TOKEN_ID);
+      await leaseAgreement.connect(lessor).startLease(TOKEN_ID, lessee.address, DURATION);
+
+      // Advance time past lease duration
+      const latestBlock = await ethers.provider.getBlock('latest');
+      await network.provider.send("evm_setNextBlockTimestamp", [latestBlock.timestamp + DURATION + 1]);
+      await network.provider.send("evm_mine");
+
+      // Other users should not be able to end lease
+      await expect(leaseAgreement.connect(lessee).endLease(TOKEN_ID))
+        .to.be.revertedWith("Not authorized");
+      await expect(leaseAgreement.connect(other).endLease(TOKEN_ID))
+        .to.be.revertedWith("Not authorized");
+    });
+
+    it("should handle forceEndLease safely", async function () {
+      // Approve RentalEngine to transfer NFT
+      await nft.connect(lessor).approve(rentalEngine.target, TOKEN_ID);
+      await leaseAgreement.connect(lessor).startLease(TOKEN_ID, lessee.address, DURATION);
+
+      await rentalEngine.forceEndLease(TOKEN_ID);
+
+      // NFT returned
+      expect(await nft.ownerOf(TOKEN_ID)).to.equal(lessor.address);
+
+      // Lease removed
+      const lease = await rentalEngine.getLeaseInfo(TOKEN_ID);
+      expect(lease.active).to.be.false;
+    });
+
+    it("should revert if lease duration too short", async function () {
+      await expect(
+        leaseAgreement.connect(lessor).startLease(TOKEN_ID, lessee.address, 0)
+      ).to.be.revertedWith("Min duration is 1 day");
+    });
+  });
+
+  describe("NFT custody & events", function () {
+    it("should keep NFT in engine during lease and emit events", async function () {
+      // Approve RentalEngine to transfer NFT
+      await nft.connect(lessor).approve(rentalEngine.target, TOKEN_ID);
+      await expect(leaseAgreement.connect(lessor).startLease(TOKEN_ID, lessee.address, DURATION))
+        .to.emit(leaseAgreement, "LeaseStarted");
+
+      expect(await nft.ownerOf(TOKEN_ID)).to.equal(rentalEngine.target);
+
+      // Advance time past lease duration
+      const latestBlock = await ethers.provider.getBlock('latest');
+      await network.provider.send("evm_setNextBlockTimestamp", [latestBlock.timestamp + DURATION + 1]);
+      await network.provider.send("evm_mine");
+
+      await expect(leaseAgreement.connect(lessor).endLease(TOKEN_ID))
+        .to.emit(leaseAgreement, "LeaseEnded");
+
+      expect(await nft.ownerOf(TOKEN_ID)).to.equal(lessor.address);
     });
   });
 });


### PR DESCRIPTION
NFT Custody: RentalEngine now keeps NFTs in custody during lease; lessee never receives direct transfer.

Trusted Modules: LeaseAgreement added as a trusted caller for registerLease.

Lease Lifecycle:

startLease validates ownership and min duration.

endLease and forceEndLease return NFT to lessor.

markDefaulted (if implemented) safely handles expired leases.

Events: Emits LeaseStarted and LeaseEnded for off-chain tracking.

Validations:

Minimum lease duration enforced.

Treasury address cannot be zero.

Testing: Full Hardhat tests covering:

Lease registration by trusted module

NFT custody in engine

Lease ending / force termination

Event emission

Reverts on invalid access or duration

Next Steps:

Implement markDefaulted expiry handling.

Integrate rental payments/escrow (if required).

Add ReentrancyGuard for sensitive functions.
<img width="1366" height="768" alt="Screenshot from 2025-08-17 21-48-42" src="https://github.com/user-attachments/assets/ce07b87a-4761-47a8-8ad0-60e60a88b6de" />

